### PR TITLE
nice message when no snapshots match the prefix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ install:
   - "pip install pytest boto==$BOTO_VERSION"
   - "python setup.py develop"
 
-script: py.test
+script: ./_tests/run_tests.sh
 
 sudo: false
 

--- a/_tests/run_tests.sh
+++ b/_tests/run_tests.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+FLAGS=""
+
+if [ -n "$S3_KEY_ID" ]; then
+    py.test
+else
+    py.test -k 'not with_s3'
+fi

--- a/z3/snap.py
+++ b/z3/snap.py
@@ -42,6 +42,21 @@ class IntegrityError(Exception):
     pass
 
 
+class SoftError(Exception):
+    pass
+
+
+def handle_soft_errors(func):
+    @functools.wraps(func)
+    def wrapper(*args, **kwargs):
+        try:
+            return func(*args, **kwargs)
+        except SoftError as err:
+            sys.stderr.write(str(err) + os.linesep)
+            sys.stderr.flush()
+    return wrapper
+
+
 class S3Snapshot(object):
     CYCLE = 'cycle detected'
     MISSING_PARENT = 'missing parent'
@@ -551,21 +566,6 @@ def parse_args():
                                 help='Force rollback of the filesystem (zfs recv -F).')
     subparsers.add_parser('status', help='show status of current backups')
     return parser.parse_args()
-
-
-class SoftError(Exception):
-    pass
-
-
-def handle_soft_errors(func):
-    @functools.wraps(func)
-    def wrapper(*args, **kwargs):
-        try:
-            return func(*args, **kwargs)
-        except SoftError as err:
-            sys.stderr.write(str(err) + os.linesep)
-            sys.stderr.flush()
-    return wrapper
 
 
 @handle_soft_errors


### PR DESCRIPTION
this should prevent issues like #5 

also, the tests only fail because people outside the Presslabs org don't have access to the credentials for S3 (which is a good thing)
