### PR TITLE
Custom host for downloads

### DIFF
--- a/z3/get.py
+++ b/z3/get.py
@@ -18,8 +18,12 @@ def main():
     )
     parser.add_argument('name', help='name of S3 key')
     args = parser.parse_args()
+    extra_config = {}
+    if 'HOST' in cfg:
+        extra_config['host'] = cfg['HOST']
     bucket = boto.connect_s3(
-        cfg['S3_KEY_ID'], cfg['S3_SECRET']).get_bucket(cfg['BUCKET'])
+        cfg['S3_KEY_ID'],
+        cfg['S3_SECRET'], **extra_config).get_bucket(cfg['BUCKET'])
     download(bucket, args.name)
 
 if __name__ == '__main__':


### PR DESCRIPTION
If configuration defines a custom host, pass it to the boto
connection configuration when downloading snapshots.