### PR TITLE
Remove underscore from metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ since the last time you've performed a backup they get exported as individual sn
 (multiple calls to `zfs send -i dataset@snapA dataset@snapB`).
 
 Your snapshots end up as individual keys in an s3 bucket, with a configurable prefix (`S3_PREFIX`).
-S3 key metadata is used to identify if a snapshot is full (`is_full="true"`) or incremental.
+S3 key metadata is used to identify if a snapshot is full (`isfull="true"`) or incremental.
 The parent of an incremental snapshot is identified with the `parent` attribute.
 
 S3 and ZFS snapshots are matched by name.

--- a/_tests/test_snap.py
+++ b/_tests/test_snap.py
@@ -33,9 +33,9 @@ class FakeBucket(object):
     rand_prefix = 'test-' + ''.join([random.choice(string.ascii_letters) for _ in xrange(8)]) + '/'
     fake_data = {
         "pool/fs@snap_0": {'parent': 'pool/fs@snap_expired'},
-        "pool/fs@snap_1_f": {'is_full': 'true', 'compressor': 'pigz1'},
+        "pool/fs@snap_1_f": {'isfull': 'true', 'compressor': 'pigz1'},
         "pool/fs@snap_2": {'parent': 'pool/fs@snap_1_f'},
-        "pool/fs@snap_3": {'parent': 'pool/fs@snap_2', 'is_full': 'false'},
+        "pool/fs@snap_3": {'parent': 'pool/fs@snap_2', 'isfull': 'false'},
         "pool/fs@snap_4_mp": {'parent': 'missing_parent'},  # missing parent
         "pool/fs@snap_5": {'parent': 'pool/fs@snap_4_mp'},
         "pool/fs@snap_6_cycle": {'parent': 'pool/fs@snap_7_cycle'},  # cycle
@@ -276,7 +276,7 @@ def test_backup_latest_full(pair_manager):
         "zfs send -nvP 'pool/fs@snap_9'",
         ("zfs send 'pool/fs@snap_9' | "
          "pput --quiet --estimated 1234 --meta size=1234 "
-         "--meta is_full=true {}pool/fs@snap_9")]
+         "--meta isfull=true {}pool/fs@snap_9")]
     assert pair_manager._cmd._called_commands == [
         e.format(FakeBucket.rand_prefix)
         for e in expected]
@@ -288,7 +288,7 @@ def test_backup_full(pair_manager):
         "zfs send -nvP 'pool/fs@snap_3'",
         ("zfs send 'pool/fs@snap_3' | "
          "pput --quiet --estimated 1234 --meta size=1234 "
-         "--meta is_full=true {}pool/fs@snap_3")]
+         "--meta isfull=true {}pool/fs@snap_3")]
     assert pair_manager._cmd._called_commands == [
         e.format(FakeBucket.rand_prefix)
         for e in expected]
@@ -389,7 +389,7 @@ def test_backup_full_compressed(s3_manager):
         "zfs send -nvP 'pool/fs@snap_8'",
         ("zfs send 'pool/fs@snap_8' | "
          "pigz -1 --blocksize 4096 | "
-         "pput --quiet --estimated 1234 --meta size=1234 --meta is_full=true "
+         "pput --quiet --estimated 1234 --meta size=1234 --meta isfull=true "
          "--meta compressor=pigz1 {}pool/fs@snap_8"),
     ]
     expected = [e.format(FakeBucket.rand_prefix) for e in commands]

--- a/z3/snap.py
+++ b/z3/snap.py
@@ -77,7 +77,8 @@ class S3Snapshot(object):
 
     @property
     def is_full(self):
-        return self._metadata.get('isfull') == 'true'
+        # keep backwards compatibility for underscore metadata
+        return 'true' in [self._metadata.get('is_full'), self._metadata.get('isfull')]
 
     @property
     def parent(self):

--- a/z3/snap.py
+++ b/z3/snap.py
@@ -77,7 +77,7 @@ class S3Snapshot(object):
 
     @property
     def is_full(self):
-        return self._metadata.get('is_full') == 'true'
+        return self._metadata.get('isfull') == 'true'
 
     @property
     def parent(self):
@@ -328,7 +328,7 @@ class PairManager(object):
     def _pput_cmd(self, estimated, s3_prefix, snap_name, parent=None):
         meta = ['size={}'.format(estimated)]
         if parent is None:
-            meta.append("is_full=true")
+            meta.append("isfull=true")
         else:
             meta.append("parent={}".format(parent))
         if self.compressor is not None:


### PR DESCRIPTION
The "x-amz-meta-" HTTP header is used as carrier for metadata.
Transporting underscores in these metadata strings can be
problematic. Thus change all "is_full" metadata entries to
"isfull".
