### PR TITLE
Add gpg as a compression option

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,9 @@ apt-get install pv
 
 # Install pigz to provide the pigz compressors.
 apt-get install pigz
+
+# Install gnupg to provide encryption and compression with gpg.
+apt-get install gnupg gnupg-agent
 ```
 
 ### Configuring
@@ -108,6 +111,28 @@ z3 restore the-part-after-the-at-sign
 
 # force rollback of filesystem (zfs recv -F)
 z3 restore the-part-after-the-at-sign --force
+```
+
+### Encryption
+Encryption of stored objects in S3 is normally provided through AWS Key Management Service (KMS). Alternatively, you can use gnupg by specifying gpg as a `COMPRESSOR` and the public key to use as `GPG_RECIPIENT`. Note: compression and crypto algorithms used by gpg are derived from the public key preferences for `GPG_RECIPIENT`. Here is a usage example:
+```
+# inspect the key preferences for z3_backup
+#   based on preference order, gpg will use AES256 cipher, and ZLIB compression
+gpg --edit-key z3_backup
+
+gpg> showpref
+[ultimate] (1). z3_backup
+     Cipher: AES256, AES192, AES, 3DES
+     Digest: SHA256, SHA384, SHA512, SHA224, SHA1
+     Compression: ZLIB, BZIP2, ZIP, Uncompressed
+     Features: MDC, Keyserver no-modify
+
+gpg> quit
+
+# perform incremental backup the latest snapshot; use gpg compressor
+z3 backup --compressor gpg --gpg-recipient z3_backup --dry-run
+# after inspectng the commands that would be executed, perform the backup
+z3 backup --compressor gpg --gpg-recipient z3_backup
 ```
 
 ### Other Commands

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ apt-get install pv
 # Install pigz to provide the pigz compressors.
 apt-get install pigz
 
-# Install gnupg to provide encryption and compression with gpg.
+# Install gnupg to provide public-key encryption and compression with gpg.
 apt-get install gnupg gnupg-agent
 ```
 
@@ -114,7 +114,7 @@ z3 restore the-part-after-the-at-sign --force
 ```
 
 ### Encryption
-Encryption of stored objects in S3 is normally provided through AWS Key Management Service (KMS). Alternatively, you can use gnupg by specifying gpg as a `COMPRESSOR` and the public key to use as `GPG_RECIPIENT`. Note: compression and crypto algorithms used by gpg are derived from the public key preferences for `GPG_RECIPIENT`. Here is a usage example:
+Encryption of stored objects in S3 is normally provided through AWS Key Management Service (KMS). Alternatively, you can use gnupg for public-key encryption by specifying gpg as a `COMPRESSOR` and the public key to use as `GPG_RECIPIENT`. Note: compression and crypto algorithms used by gpg are derived from the public key preferences for `GPG_RECIPIENT`. Here is a usage example:
 ```
 # inspect the key preferences for z3_backup
 #   based on preference order, gpg will use AES256 cipher, and ZLIB compression
@@ -129,10 +129,17 @@ gpg> showpref
 
 gpg> quit
 
+# the following assumes that you have z3_backup in your gnupg public-key ring
 # perform incremental backup the latest snapshot; use gpg compressor
 z3 backup --compressor gpg --gpg-recipient z3_backup --dry-run
 # after inspectng the commands that would be executed, perform the backup
 z3 backup --compressor gpg --gpg-recipient z3_backup
+
+# the following assumes that you have z3_backup in your gnupg private-key ring
+# restore a dataset to a certain snapshot
+z3 restore the-part-after-the-at-sign --dry-run
+# after inspectng the commands that would be executed, perform the restore
+z3 restore the-part-after-the-at-sign
 ```
 
 ### Other Commands

--- a/z3/sample.conf
+++ b/z3/sample.conf
@@ -19,7 +19,7 @@ FILESYSTEM=pool
 # only backup snapshots with this prefix
 SNAPSHOT_PREFIX=zfs-auto-snap:daily
 
-# use gpg for encryption and compression
+# use gpg for public-key encryption and compression
 COMPRESSOR=gpg
 # specify the public key to use for encryption, the public key preferences will
 #   dictate the compression and crypt algorithms used

--- a/z3/sample.conf
+++ b/z3/sample.conf
@@ -18,3 +18,9 @@ FILESYSTEM=pool
 
 # only backup snapshots with this prefix
 SNAPSHOT_PREFIX=zfs-auto-snap:daily
+
+# use gpg for encryption and compression
+COMPRESSOR=gpg
+# specify the public key to use for encryption, the public key preferences will
+#   dictate the compression and crypt algorithms used
+GPG_RECIPIENT=z3_backup

--- a/z3/snap.py
+++ b/z3/snap.py
@@ -35,6 +35,9 @@ COMPRESSORS = {
     'pigz4': {
         'compress': 'pigz -4 --blocksize 4096',
         'decompress': 'pigz -d'},
+    'gpg': {
+        'compress': 'gpg -e --cipher-algo AES256 --compress-algo zlib -r z3_backup',
+        'decompress': 'gpg -d'},
 }
 
 

--- a/z3/snap.py
+++ b/z3/snap.py
@@ -36,7 +36,7 @@ COMPRESSORS = {
         'compress': 'pigz -4 --blocksize 4096',
         'decompress': 'pigz -d'},
     'gpg': {
-        'compress': 'gpg -e --cipher-algo AES256 --compress-algo zlib -r z3_backup',
+        'compress': 'gpg -e -r z3_backup',
         'decompress': 'gpg -d'},
 }
 

--- a/z3/snap.py
+++ b/z3/snap.py
@@ -36,7 +36,7 @@ COMPRESSORS = {
         'compress': 'pigz -4 --blocksize 4096',
         'decompress': 'pigz -d'},
     'gpg': {
-        'compress': 'gpg -e -r z3_backup',
+        'compress': 'gpg -e -r {}',
         'decompress': 'gpg -d'},
 }
 
@@ -552,6 +552,11 @@ def parse_args():
                                choices=(['none'] + sorted(COMPRESSORS.keys())),
                                help=('Specify the compressor. Defaults to pigz1. '
                                      'Use "none" to disable.'))
+    backup_parser.add_argument('--gpg-recipient',
+                               dest='gpg_recipient',
+                               default=cfg.get('GPG_RECIPIENT', 'z3_backup'),
+                               help=('The gpg public key to use for encryption.'
+                                     ' Defaults to z3_backup.'))
     backup_parser.add_argument('--parseable', dest='parseable', action='store_true',
                                help='Machine readable output')
     incremental_group = backup_parser.add_mutually_exclusive_group()
@@ -602,6 +607,11 @@ def main():
             compressor = args.compressor
         if compressor.lower() == 'none':
             compressor = None
+        if compressor == 'gpg':
+            compressor_dict = COMPRESSORS.get(compressor)
+            if compressor_dict is not None:
+                compress_cmd = compressor_dict['compress'].format(args.gpg_recipient)
+                compressor_dict['compress'] = compress_cmd
 
         do_backup(bucket, s3_prefix=args.s3_prefix, snapshot_prefix=snapshot_prefix,
                   filesystem=args.filesystem, full=args.full, snapshot=args.snapshot,


### PR DESCRIPTION
The goal here is to add public-key encryption. This is very similar to https://github.com/presslabs/z3/pull/20, however, use of public-key encryption instead of a shared password helps in certain compliance situations.

The use case is to allow any number of ZFS machines with a public key to upload backups to S3. This key can be freely shared throughout the organization without fear of compromise. When restoring, access to the private key is required.

Due to its use as a compression utility and the similar nature in which gpg is implemented to other compression utilities, it made more sense to add it as a compression option instead of extending the hard work of @kithrup in the pull request mentioned above.